### PR TITLE
maven pom fix + compile fix

### DIFF
--- a/a/build.gradle
+++ b/a/build.gradle
@@ -1,23 +1,5 @@
 plugins {
-    id 'scala'
     id 'com.github.prokod.gradle-crossbuild'
 }
 
 apply from: "$rootDir/gradle/scala_211_212.gradle"
-
-// Declare the variants as "outgoing" artifacts
-configurations {
-    consumable211Jar {
-        canBeConsumed = true
-        canBeResolved = false
-    }
-    consumable212Jar {
-        canBeConsumed = true
-        canBeResolved = false
-    }
-}
-
-artifacts {
-    consumable211Jar(crossBuildScala_211Jar)
-    consumable212Jar(crossBuildScala_212Jar)
-}

--- a/d/build.gradle
+++ b/d/build.gradle
@@ -1,5 +1,4 @@
 plugins {
-    id 'scala'
     id 'com.github.prokod.gradle-crossbuild'
     id 'maven-publish'
 }
@@ -7,31 +6,15 @@ plugins {
 apply from: "$rootDir/gradle/scala_211.gradle"
 
 dependencies {
-    crossBuildScala_211Implementation project(path: ':a', configuration: 'consumable211Jar')
-    implementation project(path: ':a', configuration: 'consumable211Jar')
+    implementation project(':a')
     implementation 'org.apache.commons:commons-lang3:3.11'
 }
 
 publishing {
     publications {
-        maven211(MavenPublication) {
+        crossBuildScala_211(MavenPublication) {
             artifact crossBuildScala_211Jar
 
-            // Workaround for https://github.com/prokod/gradle-crossbuild-scala/issues/103. This should not be required.
-            pom.withXml { xml ->
-                def dependenciesNode = xml.asNode().dependencies?.getAt(0)
-                if (dependenciesNode == null) {
-                    dependenciesNode = xml.asNode().appendNode('dependencies')
-                }
-
-                project.configurations.crossBuildScala_211RuntimeClasspath.allDependencies.each { dep ->
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', dep.group)
-                    dependencyNode.appendNode('artifactId', dep.name)
-                    dependencyNode.appendNode('version', dep.version)
-                    dependencyNode.appendNode('scope', 'runtime')
-                }
-            }
         }
     }
     repositories {

--- a/gradle/scala-common.gradle
+++ b/gradle/scala-common.gradle
@@ -1,3 +1,3 @@
 crossBuild {
-    scalaVersionsCatalog = ['2.11': '2.11.12', '2.12': '2.12.12']
+    scalaVersionsCatalog = ['2.11': '2.11.12', '2.12': '2.12.13']
 }

--- a/gradle/scala_211_212.gradle
+++ b/gradle/scala_211_212.gradle
@@ -9,8 +9,8 @@ crossBuild {
 }
 
 dependencies {
-    implementation 'org.scala-lang:scala-library:2.12.13'
+    implementation 'org.scala-lang:scala-library:2.11.12'
     testImplementation 'junit:junit:4.12'
-    testImplementation 'org.scalatest:scalatest_2.12:3.1.2'
-    testImplementation 'org.scalatestplus:junit-4-12_2.12:3.1.2.0'
+    testImplementation 'org.scalatest:scalatest_2.11:3.1.2'
+    testImplementation 'org.scalatestplus:junit-4-12_2.11:3.1.2.0'
 }


### PR DESCRIPTION
After the changes in this PR, if you enter dir `d` and run
`../gradelw clean build publishToMavenLocal` couple of things to expect:
- pom file for `d` should be populated as expected
- `d` test runs as expected

Short explanation: 
- pom: by using the correct publication name to match the cross compile config, the plugin can do the matching and generate correctly the pom.
- `d` test: The test is performed on default scala version this is why I have changed default compilation in `a` in file `scala_211_212.gradle` to scala 2.11. This is currently as stated by the documentation an area I did not expand on - so test is on default scala version currently.
